### PR TITLE
Fix: webpackerのパフォーマンスサイズのmaxサイズを変える記述を追加

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,10 @@
 const { environment } = require('@rails/webpacker')
 
 module.exports = environment
+
+module.exports = {
+  performance: {
+    maxEntrypointSize: 500000,
+    maxAssetSize: 500000,
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,6 +8,5 @@ module.exports = {
       },
       stage: 3
     })
-  ],
-  performance: { hints: false }
+  ]
 }


### PR DESCRIPTION
## 概要

herokuにデプロイできる様にwebpackerのパフォーマンスサイズのmaxサイズを変える記述を追加。
